### PR TITLE
Various fixes and small improvements; Basic implementation of saveNote procedure

### DIFF
--- a/plugin/evernote.vim
+++ b/plugin/evernote.vim
@@ -23,9 +23,9 @@ function! s:ListNotebooks()
 endfunction
 
 ruby << EOF
-    require "evernote-vim/controller.rb"
-
-    $evernote = EvernoteVim::Controller.new
+  $LOAD_PATH.unshift(File.join(ENV['HOME'], '.vim', 'bundle', 'evernote.vim', 'ruby'))
+  require "evernote-vim/controller"
+  $evernote = EvernoteVim::Controller.new
 EOF
 
 map <Leader>ev :call <SID>ListNotebooks()<CR>

--- a/plugin/evernote.vim
+++ b/plugin/evernote.vim
@@ -19,7 +19,7 @@ function! s:ListNotebooks()
   exec 'silent 50vsplit evernote:notebooks'
   ruby $evernote.listNotebooks
   setlocal buftype=nofile bufhidden=hide noswapfile
-  setlocal nomodified
+  setlocal nomodifiable nomodified
 endfunction
 
 ruby << EOF

--- a/plugin/evernote.vim
+++ b/plugin/evernote.vim
@@ -16,7 +16,7 @@ if !exists('g:evernote_vim_password')
 endif
 
 function! s:ListNotebooks()
-  exec 'silent split evernote:notebooks'
+  exec 'silent 50vsplit evernote:notebooks'
   ruby $evernote.listNotebooks
   setlocal buftype=nofile bufhidden=hide noswapfile
   setlocal nomodified

--- a/ruby/evernote-vim/controller.rb
+++ b/ruby/evernote-vim/controller.rb
@@ -35,18 +35,8 @@ module EvernoteVim
         :consumer_key => @consumerKey,
         :consumer_secret => @consumerSecret
       }
-
       userStore = Evernote::UserStore.new(@userStoreUrl, config)
 
-      versionOK = userStore.checkVersion("Ruby EDAMTest",
-                                         Evernote::EDAM::UserStore::EDAM_VERSION_MAJOR,
-                                         Evernote::EDAM::UserStore::EDAM_VERSION_MINOR)
-      if !versionOK
-        put "EDAM version is out of date #{versionOK}"
-        exit 1
-      end
-
-      # Authenticate the user
       begin
         authResult = userStore.authenticate
       rescue Evernote::EDAM::Error::EDAMUserException => ex

--- a/ruby/evernote-vim/controller.rb
+++ b/ruby/evernote-vim/controller.rb
@@ -41,11 +41,11 @@ module EvernoteVim
       userStore = Evernote::EDAM::UserStore::UserStore::Client.new(userStoreProtocol)
 
       versionOK = userStore.checkVersion("Ruby EDAMTest",
-                                      Evernote::EDAM::UserStore::EDAM_VERSION_MAJOR,
-                                      Evernote::EDAM::UserStore::EDAM_VERSION_MINOR)
-      if (!versionOK)
+                                         Evernote::EDAM::UserStore::EDAM_VERSION_MAJOR,
+                                         Evernote::EDAM::UserStore::EDAM_VERSION_MINOR)
+      if !versionOK
         put "EDAM version is out of date #{versionOK}"
-        exit(1)
+        exit 1
       end
 
       # Authenticate the user
@@ -60,26 +60,26 @@ module EvernoteVim
 
         puts "Authentication failed (parameter: #{parameter} errorCode: #{errorText})"
 
-        if (errorCode == Evernote::EDAM::Error::EDAMErrorCode::INVALID_AUTH)
-          if (parameter == "consumerKey")
-            if (@consumerKey == "en-edamtest")
+        if errorCode == Evernote::EDAM::Error::EDAMErrorCode::INVALID_AUTH
+          if parameter == "consumerKey"
+            if @consumerKey == "en-edamtest"
               puts "You must replace the variables consumerKey and consumerSecret with the values you received from Evernote."
             else
               puts "Your consumer key was not accepted by #{@evernoteHost}"
             end
             puts "If you do not have an API Key from Evernote, you can request one from http://www.evernote.com/about/developer/api"
-          elsif (parameter == "username")
+          elsif parameter == "username"
             puts "You must authenticate using a username and password from #{@evernoteHost}"
-            if (@evernoteHost != "www.evernote.com")
+            if @evernoteHost != "www.evernote.com"
               puts "Note that your production Evernote account will not work on #{@evernoteHost},"
               puts "you must register for a separate test account at https://#{@evernoteHost}/Registration.action"
             end
-          elsif (parameter == "password")
+          elsif parameter == "password"
             puts "The password that you entered is incorrect"
           end
         end
 
-        exit(1)
+        exit 1
       end
 
       @user = authResult.user
@@ -104,14 +104,22 @@ module EvernoteVim
       noteStoreProtocol = Thrift::BinaryProtocol.new(noteStoreTransport)
       @noteStore = Evernote::EDAM::NoteStore::NoteStore::Client.new(noteStoreProtocol)
 
+      # Clear current buffer.
+=begin
+      for i in 1..$curbuf.length
+        $curbuf.delete(i)
+      end
+=end
+
+      # Append notebooks to current buffer.
       @notebooks = @noteStore.listNotebooks(@authToken)
-      @notebooks.each { |notebook| 
-        if (notebook.defaultNotebook)
+      @notebooks.each do |notebook|
+        if notebook.defaultNotebook
           $curbuf.append(0, "* #{notebook.name} (default)")
         else
           $curbuf.append(0, "* #{notebook.name}")
         end
-      }
+      end
 
       VIM::command("exec 'nnoremap <silent> <buffer> <cr> :ruby $evernote.selectNotebook()<cr>'")
     end

--- a/ruby/evernote-vim/controller.rb
+++ b/ruby/evernote-vim/controller.rb
@@ -105,11 +105,9 @@ module EvernoteVim
       @noteStore = Evernote::EDAM::NoteStore::NoteStore::Client.new(noteStoreProtocol)
 
       # Clear current buffer.
-=begin
-      for i in 1..$curbuf.length
-        $curbuf.delete(i)
+      while $curbuf.count > 1
+        $curbuf.delete $curbuf.count
       end
-=end
 
       # Append notebooks to current buffer.
       @notebooks = @noteStore.listNotebooks(@authToken)
@@ -120,6 +118,10 @@ module EvernoteVim
           $curbuf.append(0, "* #{notebook.name}")
         end
       end
+
+      # VIM::Buffer.append adds an empty line after the appended line.
+      # Delete it.
+      $curbuf.delete $curbuf.count
 
       VIM::command("exec 'nnoremap <silent> <buffer> <cr> :ruby $evernote.selectNotebook()<cr>'")
     end

--- a/ruby/evernote-vim/controller.rb
+++ b/ruby/evernote-vim/controller.rb
@@ -6,10 +6,7 @@ require "thrift/protocol/base_protocol"
 require "thrift/protocol/binary_protocol"
 require "thrift/transport/base_transport"
 require "thrift/transport/http_client_transport"
-require "Evernote/EDAM/user_store"
-require "Evernote/EDAM/user_store_constants.rb"
-require "Evernote/EDAM/note_store"
-require "Evernote/EDAM/limits_constants.rb"
+require "evernote"
 
 module EvernoteVim
   class Controller

--- a/ruby/evernote-vim/controller.rb
+++ b/ruby/evernote-vim/controller.rb
@@ -36,9 +36,14 @@ module EvernoteVim
         VIM::command("let g:evernote_vim_password = user_input")
       end
 
-      userStoreTransport = Thrift::HTTPClientTransport.new(@userStoreUrl)
-      userStoreProtocol = Thrift::BinaryProtocol.new(userStoreTransport)
-      userStore = Evernote::EDAM::UserStore::UserStore::Client.new(userStoreProtocol)
+      config = {
+        :username => username,
+        :password => password,
+        :consumer_key => @consumerKey,
+        :consumer_secret => @consumerSecret
+      }
+
+      userStore = Evernote::UserStore.new(@userStoreUrl, config)
 
       versionOK = userStore.checkVersion("Ruby EDAMTest",
                                          Evernote::EDAM::UserStore::EDAM_VERSION_MAJOR,
@@ -50,8 +55,7 @@ module EvernoteVim
 
       # Authenticate the user
       begin
-        authResult = userStore.authenticate(username, password,
-                                            @consumerKey, @consumerSecret)
+        authResult = userStore.authenticate
       rescue Evernote::EDAM::Error::EDAMUserException => ex
         # See http://www.evernote.com/about/developer/api/ref/UserStore.html#Fn_UserStore_authenticate
         parameter = ex.parameter
@@ -100,9 +104,7 @@ module EvernoteVim
       authenticate_if_needed
 
       noteStoreUrl = @noteStoreUrlBase + @user.shardId
-      noteStoreTransport = Thrift::HTTPClientTransport.new(noteStoreUrl)
-      noteStoreProtocol = Thrift::BinaryProtocol.new(noteStoreTransport)
-      @noteStore = Evernote::EDAM::NoteStore::NoteStore::Client.new(noteStoreProtocol)
+      @noteStore = Evernote::NoteStore.new(noteStoreUrl)
 
       # Clear current buffer.
       while $curbuf.count > 1

--- a/ruby/evernote-vim/controller.rb
+++ b/ruby/evernote-vim/controller.rb
@@ -118,9 +118,7 @@ module EvernoteVim
           $curbuf.append(0, "* #{notebook.name}")
         end
       end
-
-      # VIM::Buffer.append adds an empty line after the appended line.
-      # Delete it.
+      # VIM::Buffer.append adds an empty line after the appended line. Delete it.
       $curbuf.delete $curbuf.count
 
       VIM::command("exec 'nnoremap <silent> <buffer> <cr> :ruby $evernote.selectNotebook()<cr>'")
@@ -138,10 +136,11 @@ module EvernoteVim
 
       @prevBuffer << $curbuf.number
       VIM::command("q")
-      VIM::command("silent split evernote:notes")
+      VIM::command("silent 50vsplit evernote:notes")
       @noteList.notes.each do |note|
         $curbuf.append(0, note.title)
       end
+      $curbuf.delete $curbuf.count
 
       VIM::command("setlocal buftype=nofile bufhidden=unload noswapfile")
       VIM::command("setlocal nomodified")
@@ -155,10 +154,11 @@ module EvernoteVim
       note = @noteList.notes.detect { |n| n.title == line }
       content = @noteStore.getNoteContent(@authToken, note.guid)
 
-      # Create a new buffer
-      VIM::command("silent split evernote:#{note.title.gsub(/\s/, '-')}")
+      # Create new buffer to the right.
+      VIM::command("silent wincmd l")
+      VIM::command("silent edit evernote:#{note.title.gsub(/\s/, '-')}")
 
-      # Append Note Content
+      # Append Note Content.
       content = /<en-note>(.+)<\/en-note>/.match(content)[1]
       content = content.gsub(/<br( \/)?>/, "\n").gsub(/<([a-z\-\/]+)>/i, '')
 

--- a/ruby/evernote-vim/controller.rb
+++ b/ruby/evernote-vim/controller.rb
@@ -41,7 +41,7 @@ module EvernoteVim
       begin
         authResult = userStore.authenticate
       rescue Evernote::UserStore::AuthenticationFailure
-        VIM::message("An error occurred while authenticated to Evernote")
+        VIM::message("An error occurred while authenticating to Evernote")
         exit 1
       end
 

--- a/ruby/evernote-vim/controller.rb
+++ b/ruby/evernote-vim/controller.rb
@@ -143,7 +143,7 @@ module EvernoteVim
       $curbuf.delete $curbuf.count
 
       VIM::command("setlocal buftype=nofile bufhidden=unload noswapfile")
-      VIM::command("setlocal nomodified")
+      VIM::command("setlocal nomodifiable nomodified")
       VIM::command("exec 'nnoremap <silent> <buffer> <cr> :ruby $evernote.selectNote()<cr>'")
       VIM::command("map <silent> <buffer> <C-T> :ruby $evernote.previousScreen()<cr>")
     end

--- a/ruby/evernote-vim/controller.rb
+++ b/ruby/evernote-vim/controller.rb
@@ -150,7 +150,7 @@ module EvernoteVim
     def get_text(element)
       all_text = element.inject("") do |memo, child|
         if child.is_a? REXML::Text
-          memo += child.to_s + "\n"
+          memo += child.to_s
         else
           memo += get_text(child)
         end

--- a/ruby/evernote-vim/controller.rb
+++ b/ruby/evernote-vim/controller.rb
@@ -1,3 +1,4 @@
+require "rubygems"
 require "digest/md5"
 require "thrift/types"
 require "thrift/struct"

--- a/ruby/evernote-vim/controller.rb
+++ b/ruby/evernote-vim/controller.rb
@@ -118,7 +118,7 @@ module EvernoteVim
       VIM::command("silent wincmd l")
       VIM::command("silent edit evernote:#{@note.title.gsub(/\s/, '-')}")
 
-      # Append note content.
+      # Parse XML and append it note buffer.
       doc = REXML::Document.new(xmlContent)
       $curbuf.append(0, get_text(doc.elements['en-note']))
       VIM::command("setlocal nomodified")

--- a/ruby/evernote-vim/controller.rb
+++ b/ruby/evernote-vim/controller.rb
@@ -1,11 +1,4 @@
 require "rubygems"
-require "digest/md5"
-require "thrift/types"
-require "thrift/struct"
-require "thrift/protocol/base_protocol"
-require "thrift/protocol/binary_protocol"
-require "thrift/transport/base_transport"
-require "thrift/transport/http_client_transport"
 require "evernote"
 
 module EvernoteVim


### PR DESCRIPTION
I made various changes including:
- Ease loading of the controller ruby library from VIM.
- Split buffers vertically rather than horizontally (similar to NERDTree).
- Use evernote gem public API rather than the private Evernote::EDAM API.
- Use REXML to parse note content rather than regex.
- Provide basic implementation of the saveNote procedure.
- Miscellaneous small bug fixes and code refactoring.

Please review and feel free to merge my changes. Let me know if you have any question.

Thanks,
Martin
