### PR TITLE
Fix ruby loading issue (g:evernote_vim_ruby_dir variable); Parse notes using REXML SAX interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,12 @@ In the [TODO.md](evernote.vim/blob/master/TODO.md) file there is a semi-up to da
 * Add the following variables to your .vimrc:
 
   `let g:evernote_vim_username = "your_evernote_username"`
+
   `let g:evernote_vim_password = "your_evernote_password"`
+
   `let g:evernote_vim_ruby_dir = "full_path_to_the_evernote_vim_ruby_directory"`
 
-For example:
+For example, on OS X:
 
   `let g:evernote_vim_ruby_dir = "/Users/evernotelover/.vim/bundle/evernote.vim/ruby"`
 

--- a/README.md
+++ b/README.md
@@ -6,14 +6,18 @@ In the [TODO.md](evernote.vim/blob/master/TODO.md) file there is a semi-up to da
 
 #Installation
 * Ensure that your Vim has ruby baked-in.
-  `vim --version | grep ruby` should show the `+ruby` flag
-* Install the [evernote gem](http://rubygems.org/gems/evernote)
+
+  `vim --version | grep ruby` should show the `+ruby` flag.
+* Install the [evernote gem](http://rubygems.org/gems/evernote).
 * Install the evernote.vim plugin as you would install any other Vim plugin. You can obviously use [Pathogen](https://github.com/tpope/vim-pathogen/).
 * Add the following variables to your .vimrc:
+
   `let g:evernote_vim_username = "your_evernote_username"`
   `let g:evernote_vim_password = "your_evernote_password"`
   `let g:evernote_vim_ruby_dir = "full_path_to_the_evernote_vim_ruby_directory"`
+
 For example:
+
   `let g:evernote_vim_ruby_dir = "/Users/evernotelover/.vim/bundle/evernote.vim/ruby"`
 
 #Source Structure

--- a/README.md
+++ b/README.md
@@ -1,15 +1,20 @@
-A vim plugin to edit Evernote notes
-
+A vim plugin to view and edit Evernote notes 
 #Current State
 This is currently in very early stages of develoment; it is still using the official [Evernote sandbox](http://sandbox.evernote.com/) until there is a stable version that can read from Evernote.
 
 In the [TODO.md](evernote.vim/blob/master/TODO.md) file there is a semi-up to date list of things that need done.
 
-#Requirements
-* vim with ruby baked-in
-* the [evernote gem](http://rubygems.org/gems/evernote)
+#Installation
+* Ensure that your Vim has ruby baked-in.
+  `vim --version | grep ruby` should show the `+ruby` flag
+* Install the [evernote gem](http://rubygems.org/gems/evernote)
+* Install the evernote.vim plugin as you would install any other Vim plugin. You can obviously use [Pathogen](https://github.com/tpope/vim-pathogen/).
+* Add the following variables to your .vimrc:
+  `let g:evernote_vim_username = "your_evernote_username"`
+  `let g:evernote_vim_password = "your_evernote_password"`
+  `let g:evernote_vim_ruby_dir = "full_path_to_the_evernote_vim_ruby_directory"`
+For example:
+  `let g:evernote_vim_ruby_dir = "/Users/evernotelover/.vim/bundle/evernote.vim/ruby"`
 
 #Source Structure
 [plugin/evernote.vim](evernote.vim/blob/master/plugin/evernote.vim) is just a small shim that loads [ruby/evernote-vim/controller.rb](evernote.vim/blob/master/ruby/evernote-vim/controller.rb), where the real work happens.
-                                                                       
-                                                                      

--- a/plugin/evernote.vim
+++ b/plugin/evernote.vim
@@ -23,7 +23,7 @@ function! s:ListNotebooks()
   exec 'silent 50vsplit evernote:notebooks'
   ruby $evernote.listNotebooks
   setlocal buftype=nofile bufhidden=hide noswapfile
-  setlocal nomodifiable nomodified
+  setlocal nomodified
 endfunction
 
 ruby << EOF
@@ -41,7 +41,7 @@ ruby << EOF
       @ssl_context.verify_mode = OpenSSL::SSL::VERIFY_NONE
     end
   end
-  require "evernote-vim/controller"
+  Dir["#{ruby_dir}/evernote-vim/*.rb"].each {|file| require file }
   $evernote = EvernoteVim::Controller.new
 EOF
 

--- a/plugin/evernote.vim
+++ b/plugin/evernote.vim
@@ -15,6 +15,10 @@ if !exists('g:evernote_vim_password')
   let g:evernote_vim_password = ''
 endif
 
+if !exists('g:evernote_vim_ruby_dir')
+  let g:evernote_vim_ruby_dir = ''
+endif
+
 function! s:ListNotebooks()
   exec 'silent 50vsplit evernote:notebooks'
   ruby $evernote.listNotebooks
@@ -23,7 +27,10 @@ function! s:ListNotebooks()
 endfunction
 
 ruby << EOF
-  $LOAD_PATH.unshift(File.join(ENV['HOME'], '.vim', 'bundle', 'evernote.vim', 'ruby'))
+  ruby_dir = VIM::evaluate("g:evernote_vim_ruby_dir").empty? ? \
+             File.join(ENV['HOME'], '.vim', 'bundle', 'evernote.vim', 'ruby') : \
+             VIM::evaluate("g:evernote_vim_ruby_dir")
+  $LOAD_PATH.unshift(ruby_dir)
   require "evernote-vim/controller"
   $evernote = EvernoteVim::Controller.new
 EOF

--- a/ruby/evernote-vim/note_parser.rb
+++ b/ruby/evernote-vim/note_parser.rb
@@ -1,0 +1,29 @@
+module EvernoteVim
+  class NoteParser
+    def initialize
+      @content = [] # the array of lines representing a note
+      @line = 0 # starting line index at 0
+    end
+
+    def tag_start(name, attrs)
+    end
+
+    def tag_end(name)
+      @line += 1 if name == "br"
+    end
+
+    def text(str)
+      @content[@line] = (@content[@line] || "") + str
+    end
+
+    def doctype(name, pub_sys, long_name, uri)
+    end
+
+    def xmldecl(version, encoding, standalone)
+    end
+
+    def get_content
+      @content
+    end
+  end
+end


### PR DESCRIPTION
I added a g:evernote_vim_ruby_dir variable that can be set in your .vimrc to specify the location of the ruby directory of the Evernote Vim plugin. For example, in my case I can set it to the following since I'm using Pathogen:

let g:evernote_vim_ruby_dir = "/Users/evernotelover/.vim/bundle/evernote.vim/ruby"

The README file is updated accordingly.

Also, this pull request contains a new implementation of the openNote() procedure. I'm using the REXML SAX interface to parse a note (instead of the default DOM interface) in order to properly handle return carriages.

Thanks for fixing the SSL warning BTW. Let me know if you have any questions.
