### PR TITLE
call File.expand_path on ruby_dir, in case it contains '~'

### DIFF
--- a/plugin/evernote.vim
+++ b/plugin/evernote.vim
@@ -29,7 +29,7 @@ endfunction
 ruby << EOF
   ruby_dir = VIM::evaluate("g:evernote_vim_ruby_dir").empty? ? \
              File.join(ENV['HOME'], '.vim', 'bundle', 'evernote.vim', 'ruby') : \
-             VIM::evaluate("g:evernote_vim_ruby_dir")
+             File.expand_path(VIM::evaluate("g:evernote_vim_ruby_dir"))
   $LOAD_PATH.unshift(ruby_dir)
   require 'net/http'
   # hack to eliminate the SSL certificate verification notification


### PR DESCRIPTION
I had to call `File.expand_path` on the ruby_dir variable, because it contained '~' which wasn't getting expanded to my home directory properly, causing the files to not be required.
